### PR TITLE
Fixing .kt regex

### DIFF
--- a/lib/android_rename_steps.dart
+++ b/lib/android_rename_steps.dart
@@ -65,7 +65,8 @@ class AndroidRenameSteps {
     var extension = type == 'java' ? 'java' : 'kt';
     print('Project is using $type');
     print('Updating MainActivity.$extension');
-    await replaceInFileRegex(path.path, r'(^package .*$)', "package ${newPackageName}");
+    await replaceInFileRegex(
+        path.path, r'^(package (?:\.|\w)+)', "package ${newPackageName}");
 
     String newPackagePath = newPackageName.replaceAll('.', '/');
     String newPath = '${PATH_ACTIVITY}${type}/$newPackagePath';

--- a/lib/android_rename_steps.dart
+++ b/lib/android_rename_steps.dart
@@ -65,7 +65,7 @@ class AndroidRenameSteps {
     var extension = type == 'java' ? 'java' : 'kt';
     print('Project is using $type');
     print('Updating MainActivity.$extension');
-    await replaceInFileRegex(path.path, '(^package .*\$)', "package ${newPackageName}");
+    await replaceInFileRegex(path.path, r'(^package .*$)', "package ${newPackageName}");
 
     String newPackagePath = newPackageName.replaceAll('.', '/');
     String newPath = '${PATH_ACTIVITY}${type}/$newPackagePath';

--- a/lib/android_rename_steps.dart
+++ b/lib/android_rename_steps.dart
@@ -65,7 +65,7 @@ class AndroidRenameSteps {
     var extension = type == 'java' ? 'java' : 'kt';
     print('Project is using $type');
     print('Updating MainActivity.$extension');
-    await replaceInFileRegex(path.path, '(package.*)', "package ${newPackageName}");
+    await replaceInFileRegex(path.path, '(^package .*$)', "package ${newPackageName}");
 
     String newPackagePath = newPackageName.replaceAll('.', '/');
     String newPath = '${PATH_ACTIVITY}${type}/$newPackagePath';

--- a/lib/android_rename_steps.dart
+++ b/lib/android_rename_steps.dart
@@ -65,7 +65,7 @@ class AndroidRenameSteps {
     var extension = type == 'java' ? 'java' : 'kt';
     print('Project is using $type');
     print('Updating MainActivity.$extension');
-    await replaceInFileRegex(path.path, '(^package .*$)', "package ${newPackageName}");
+    await replaceInFileRegex(path.path, '(^package .*\$)', "package ${newPackageName}");
 
     String newPackagePath = newPackageName.replaceAll('.', '/');
     String newPath = '${PATH_ACTIVITY}${type}/$newPackagePath';


### PR DESCRIPTION
Changing the regex pattern to ensure we only replace lines starting with `package `. Without this, we are replacing code like the following:
```
class MainActivity: FlutterActivity() {
       override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
        super.configureFlutterEngine(flutterEngine)

        val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
        ...
    }
}
```
as it will replace the `line after packageManager...` for the new package name