### PR TITLE
Platform-specific flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Change App Package Name with single command. It makes the process very easy and 
 - [x] Delete old package name directory structure.
 - [x] Update Product Bundle Identifier in iOS.
   - if you have customized CFBundleIdentifier in Info.plist, it will not be updated. You have to update it manually.
+- [x] Specify which platform they want to rename the package for.
 
 ## How to Use?
 
 Add Change App Package Name to your `pubspec.yaml` in `dev_dependencies:` section. 
 ```yaml
 dev_dependencies: 
-  change_app_package_name: ^1.3.0
+  change_app_package_name: ^1.4.0
 ```
 or run this command
 ```bash
@@ -24,7 +25,7 @@ flutter pub add -d change_app_package_name
 Not migrated to null safety yet? use old version like this
 ```yaml
 dev_dependencies: 
-  change_app_package_name: ^0.1.3
+  change_app_package_name: ^1.4.0
 ```
 
 
@@ -32,11 +33,20 @@ Update dependencies
 ```
 flutter pub get
 ```
-Run this command to change the package name.
+Run this command to change the package name for both platforms.
 
 ```
 dart run change_app_package_name:main com.new.package.name
 ```
+To rename only Android:
+```
+dart run change_app_package_name:main com.new.package.name --android
+```
+To rename only IOS:
+```
+dart run change_app_package_name:main com.new.package.name --ios
+```
+
 Where `com.new.package.name` is the new package name that you want for your app. replace it with any name you want.
 
 ## Meta

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,4 +1,4 @@
-import 'package:change_app_package_name/change_app_package_name.dart';
+import '../lib/change_app_package_name.dart';
 
 void main(List<String> arguments) {
   ChangeAppPackageName.start(arguments);

--- a/lib/android_rename_steps.dart
+++ b/lib/android_rename_steps.dart
@@ -102,7 +102,7 @@ class AndroidRenameSteps {
     }
   }
 
-  Future<File?> findMainActivity({String type: 'java'}) async {
+  Future<File?> findMainActivity({String type = 'java'}) async {
     var files = await dirContents(Directory(PATH_ACTIVITY + type));
     String extension = type == 'java' ? 'java' : 'kt';
     for (var item in files) {

--- a/lib/change_app_package_name.dart
+++ b/lib/change_app_package_name.dart
@@ -4,14 +4,35 @@ import './android_rename_steps.dart';
 import './ios_rename_steps.dart';
 
 class ChangeAppPackageName {
-  static void start(List<String> arguments) async {
+  static Future<void> start(List<String> arguments) async {
     if (arguments.isEmpty) {
-      print('New package name is missing in paraments. please try again.');
-    } else if (arguments.length > 1) {
-      print('Wrong arguments, this package accepts only new package name');
-    } else {
-      await AndroidRenameSteps(arguments[0]).process();
-      await IosRenameSteps(arguments[0]).process();
+      print('New package name is missing. Please provide a package name.');
+      return;
     }
+
+    if (arguments.length == 1) {
+      // No platform-specific flag, rename both Android and iOS
+      print('Renaming package for both Android and iOS.');
+      await _renameBoth(arguments[0]);
+    } else if (arguments.length == 2) {
+      // Check for platform-specific flags
+      var platform = arguments[1].toLowerCase();
+      if (platform == '--android') {
+        print('Renaming package for Android only.');
+        await AndroidRenameSteps(arguments[0]).process();
+      } else if (platform == '--ios') {
+        print('Renaming package for iOS only.');
+        await IosRenameSteps(arguments[0]).process();
+      } else {
+        print('Invalid argument. Use "--android" or "--ios".');
+      }
+    } else {
+      print('Too many arguments. This package accepts only the new package name and an optional platform flag.');
+    }
+  }
+
+  static Future<void> _renameBoth(String newPackageName) async {
+    await AndroidRenameSteps(newPackageName).process();
+    await IosRenameSteps(newPackageName).process();
   }
 }


### PR DESCRIPTION
# platform-specific flags for package

This PR introduces a new feature that allows users to specify which platform (Android, iOS, or both) and will close #42 they want to rename the package for. Previously, the package would always rename both Android and iOS package identifiers. With this change, users can now choose to rename the package for a specific platform by passing a flag.

## What's Changed:

1 - New Flags for Platform Selection:

- Added support for `--android` and `--ios` flags.
- Users can now specify which platform they want to rename the package for, providing more control and flexibility.
- If no flags are passed, the package will default to renaming both Android and iOS platforms, maintaining backward compatibility.

2 - Command Usage:

- To rename both Android and iOS (default behavior):
```arduino
dart run change_app_package_name:main com.new.package.name
```
- To rename only Android:
```arduino
dart run change_app_package_name:main com.new.package.name --android
```
- To rename only IOS:
```arduino
dart run change_app_package_name:main com.new.package.name --ios
```