### PR TITLE
Add tld domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,13 +31,13 @@
 build/
 
 # Android related
-**/android/**/gradle-wrapper.jar
-**/android/.gradle
-**/android/captures/
-**/android/gradlew
-**/android/gradlew.bat
-**/android/local.properties
-**/android/**/GeneratedPluginRegistrant.java
+lib/platforms/android/**/gradle-wrapper.jar
+lib/platforms/android/.gradle
+lib/platforms/android/captures/
+lib/platforms/android/gradlew
+lib/platforms/android/gradlew.bat
+lib/platforms/android/local.properties
+lib/platforms/android/**/GeneratedPluginRegistrant.java
 
 # iOS/XCode related
 **/ios/**/*.mode1v3
@@ -45,31 +45,31 @@ build/
 **/ios/**/*.moved-aside
 **/ios/**/*.pbxuser
 **/ios/**/*.perspectivev3
-**/ios/**/*sync/
-**/ios/**/.sconsign.dblite
-**/ios/**/.tags*
-**/ios/**/.vagrant/
-**/ios/**/DerivedData/
-**/ios/**/Icon?
-**/ios/**/Pods/
-**/ios/**/.symlinks/
-**/ios/**/profile
-**/ios/**/xcuserdata
-**/ios/.generated/
-**/ios/Flutter/App.framework
-**/ios/Flutter/Flutter.framework
-**/ios/Flutter/Flutter.podspec
-**/ios/Flutter/Generated.xcconfig
-**/ios/Flutter/app.flx
-**/ios/Flutter/app.zip
-**/ios/Flutter/flutter_assets/
-**/ios/Flutter/flutter_export_environment.sh
-**/ios/ServiceDefinitions.json
-**/ios/Runner/GeneratedPluginRegistrant.*
+lib/platforms/ios/**/*sync/
+lib/platforms/ios/**/.sconsign.dblite
+lib/platforms/ios/**/.tags*
+lib/platforms/ios/**/.vagrant/
+lib/platforms/ios/**/DerivedData/
+lib/platforms/ios/**/Icon?
+lib/platforms/ios/**/Pods/
+lib/platforms/ios/**/.symlinks/
+lib/platforms/ios/**/profile
+lib/platforms/ios/**/xcuserdata
+lib/platforms/ios/.generated/
+lib/platforms/ios/Flutter/App.framework
+lib/platforms/ios/Flutter/Flutter.framework
+lib/platforms/ios/Flutter/Flutter.podspec
+lib/platforms/ios/Flutter/Generated.xcconfig
+lib/platforms/ios/Flutter/app.flx
+lib/platforms/ios/Flutter/app.zip
+lib/platforms/ios/Flutter/flutter_assets/
+lib/platforms/ios/Flutter/flutter_export_environment.sh
+lib/platforms/ios/ServiceDefinitions.json
+lib/platforms/ios/Runner/GeneratedPluginRegistrant.*
 
 # Exceptions to above rules.
-!**/ios/**/default.mode1v3
-!**/ios/**/default.mode2v3
-!**/ios/**/default.pbxuser
-!**/ios/**/default.perspectivev3
+!lib/platforms/ios/**/default.mode1v3
+!lib/platforms/ios/**/default.mode2v3
+!lib/platforms/ios/**/default.pbxuser
+!lib/platforms/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ To rename only Android:
 ```
 dart run change_app_package_name:main com.new.package.name --android
 ```
->![Note]
-> jskaf;jasfdk;l
+>[!NOTE]
+> Kotlin treats is, in, and as keywords, which can conflict with some package names.
+> So if your package name is like `com.is.example`
+> ``` 
+> package `is`.example
+> ```
 
 To rename only IOS:
 ```

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ Change App Package Name with single command. It makes the process very easy and 
 - [x] Update Product Bundle Identifier in iOS.
   - if you have customized CFBundleIdentifier in Info.plist, it will not be updated. You have to update it manually.
 - [x] Specify which platform they want to rename the package for.
+- [x] Handles Kotlin reserved keywords in package names
+- [ ] Windows support
 
 ## How to Use?
 
 Add Change App Package Name to your `pubspec.yaml` in `dev_dependencies:` section. 
 ```yaml
 dev_dependencies: 
-  change_app_package_name: ^1.4.0
+  change_app_package_name: ^1.4.1
 ```
 or run this command
 ```bash
@@ -25,7 +27,7 @@ flutter pub add -d change_app_package_name
 Not migrated to null safety yet? use old version like this
 ```yaml
 dev_dependencies: 
-  change_app_package_name: ^1.4.0
+  change_app_package_name: ^1.4.1
 ```
 
 
@@ -42,6 +44,9 @@ To rename only Android:
 ```
 dart run change_app_package_name:main com.new.package.name --android
 ```
+>![Note]
+> jskaf;jasfdk;l
+
 To rename only IOS:
 ```
 dart run change_app_package_name:main com.new.package.name --ios

--- a/lib/change_app_package_name.dart
+++ b/lib/change_app_package_name.dart
@@ -1,7 +1,6 @@
 library change_app_package_name;
 
-import './android_rename_steps.dart';
-import './ios_rename_steps.dart';
+import 'platforms/platforms.dart';
 
 class ChangeAppPackageName {
   static Future<void> start(List<String> arguments) async {

--- a/lib/helpers/extensions/extensions.dart
+++ b/lib/helpers/extensions/extensions.dart
@@ -1,0 +1,2 @@
+
+part 'kotlin_package_name_escaper.dart';

--- a/lib/helpers/extensions/kotlin_package_name_escaper.dart
+++ b/lib/helpers/extensions/kotlin_package_name_escaper.dart
@@ -1,0 +1,15 @@
+part of 'extensions.dart';
+
+extension KotlinPackageNameEscaper on String {
+  String escapeKotlinKeywords() {
+    return this
+        .split('.')
+        .map((segment) {
+      if (['is', 'in', 'as'].contains(segment)) {
+        return '`$segment`';
+      }
+      return segment;
+    })
+        .join('.');
+  }
+}

--- a/lib/helpers/utils/file_utils.dart
+++ b/lib/helpers/utils/file_utils.dart
@@ -1,4 +1,5 @@
-import 'dart:io';
+part of 'utils.dart';
+
 
 Future<void> replaceInFile(String path, oldPackage, newPackage) async {
   String? contents = await readFileAsString(path);

--- a/lib/helpers/utils/utils.dart
+++ b/lib/helpers/utils/utils.dart
@@ -1,0 +1,4 @@
+import 'dart:io';
+
+
+part 'file_utils.dart';

--- a/lib/platforms/android/android.dart
+++ b/lib/platforms/android/android.dart
@@ -1,0 +1,9 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:change_app_package_name/helpers/extensions/extensions.dart';
+
+import '../../helpers/utils/utils.dart';
+
+
+part 'android_rename_steps.dart';

--- a/lib/platforms/android/android_rename_steps.dart
+++ b/lib/platforms/android/android_rename_steps.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-import 'dart:io';
-
-import './file_utils.dart';
+part of 'android.dart';
 
 class AndroidRenameSteps {
   final String newPackageName;
@@ -71,8 +68,12 @@ class AndroidRenameSteps {
     var extension = type == 'java' ? 'java' : 'kt';
     print('Project is using $type');
     print('Updating MainActivity.$extension');
+
+    // Use the extension method to escape Kotlin keywords
+    var escapedPackageName = newPackageName.escapeKotlinKeywords();
+
     await replaceInFileRegex(
-        path.path, r'^(package (?:\.|\w)+)', "package ${newPackageName}");
+        path.path, r'^(package (?:\.|\w)+)', "package $escapedPackageName");
 
     String newPackagePath = newPackageName.replaceAll('.', '/');
     String newPath = '${PATH_ACTIVITY}${type}/$newPackagePath';
@@ -82,9 +83,9 @@ class AndroidRenameSteps {
     await path.rename(newPath + '/MainActivity.$extension');
 
     print('Deleting old directories');
-
     await deleteEmptyDirs(type);
   }
+
 
   Future<void> _replace(String path) async {
     await replaceInFile(path, oldPackageName, newPackageName);

--- a/lib/platforms/ios/ios.dart
+++ b/lib/platforms/ios/ios.dart
@@ -1,0 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../../helpers/utils/utils.dart';
+
+part 'ios_rename_steps.dart';

--- a/lib/platforms/ios/ios_rename_steps.dart
+++ b/lib/platforms/ios/ios_rename_steps.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-import 'dart:io';
-
-import './file_utils.dart';
+part of 'ios.dart';
 
 class IosRenameSteps {
   final String newPackageName;

--- a/lib/platforms/platforms.dart
+++ b/lib/platforms/platforms.dart
@@ -1,0 +1,3 @@
+
+export  'ios/ios.dart';
+export 'android/android.dart';


### PR DESCRIPTION
## Description of Changes
- Kotlin Keyword Escaping for TLDs: Added support for escaping Kotlin keywords (is, in, as) that conflict with top-level domains such as.is (Iceland), .in (India), and .as (American Samoa). This ensures that package names containing these keywords are properly handled in Kotlin files.

  - Introduced the `escapeKotlinKeywords` extension, which wraps conflicting keywords with backticks in package names.
  - Updated processMainActivity to apply the escaped package names when renaming `MainActivity.kt`.

- Change the folder structure for scalability and maintainability.

![image](https://github.com/user-attachments/assets/7b6e0b05-2ddb-4b78-9e76-e3ed47eb9669)

merging this will close #41 
