### PR TITLE
Add --rename-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ dart run change_app_package_name:main com.new.package.name --ios
 
 Where `com.new.package.name` is the new package name that you want for your app. replace it with any name you want.
 
+If you don't want to move Android activity files to new directory associated with package name (default action) use command `--rename-only`:
+```
+dart run change_app_package_name:main com.new.package.name --rename-only
+```
+or
+```
+dart run change_app_package_name:main com.new.package.name --android --rename-only
+```
 ## Meta
 
 Atiq Samtia– [@AtiqSamtia](https://twitter.com/atiqsamtia) – me@atiqsamtia.com

--- a/lib/change_app_package_name.dart
+++ b/lib/change_app_package_name.dart
@@ -13,26 +13,43 @@ class ChangeAppPackageName {
     if (arguments.length == 1) {
       // No platform-specific flag, rename both Android and iOS
       print('Renaming package for both Android and iOS.');
-      await _renameBoth(arguments[0]);
-    } else if (arguments.length == 2) {
+      return await _renameBoth(arguments.first);
+    }
+    if (arguments.length <= 3) {
       // Check for platform-specific flags
-      var platform = arguments[1].toLowerCase();
-      if (platform == '--android') {
+      final argument1 = arguments.elementAt(1).toLowerCase();
+      final argument2 = arguments.elementAtOrNull(2)?.toLowerCase();
+      if (argument1 == '--android') {
         print('Renaming package for Android only.');
-        await AndroidRenameSteps(arguments[0]).process();
-      } else if (platform == '--ios') {
-        print('Renaming package for iOS only.');
-        await IosRenameSteps(arguments[0]).process();
-      } else {
-        print('Invalid argument. Use "--android" or "--ios".');
+        final isRenameOnly = argument2 == '--rename-only';
+        return await AndroidRenameSteps(
+          newPackageName: arguments.first,
+          updateActivityFiles: !isRenameOnly,
+        ).process();
       }
+      if (argument1 == '--ios') {
+        print('Renaming package for iOS only.');
+        return await IosRenameSteps(arguments.first).process();
+      }
+
+      if (argument1 == '--rename-only') {
+        return await _renameBoth(arguments.first, false);
+      }
+
+      print('Invalid argument. Use "--android" or "--ios".');
     } else {
       print('Too many arguments. This package accepts only the new package name and an optional platform flag.');
     }
   }
 
-  static Future<void> _renameBoth(String newPackageName) async {
-    await AndroidRenameSteps(newPackageName).process();
+  static Future<void> _renameBoth(
+    String newPackageName, [
+    bool updateActivityFiles = true,
+  ]) async {
+    await AndroidRenameSteps(
+      newPackageName: newPackageName,
+      updateActivityFiles: updateActivityFiles,
+    ).process();
     await IosRenameSteps(newPackageName).process();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,4 +2,4 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=2.12.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,4 @@ maintainer: Atiq Samtia (@AtiqSamtia)
 homepage: https://github.com/atiqsamtia/change_app_package_name
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
This PR adding --rename-only option for android in case we don't want to move android files to new directory and only want to change package name. Useful for easy switch between envorionments